### PR TITLE
Make estuary-docker compile times 2x faster

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - estuary:/usr/estuary/private
+      - estuary-bin:/usr/estuary-bin/
     environment:
       - ESTUARY_DATABASE=sqlite=/usr/src/estuary/data/estuary.db
       - ESTUARY_DATADIR=/usr/src/estuary/data/
@@ -17,17 +18,18 @@ services:
       - "3004:3004/udp"
   
   estuary-shuttle:
+    depends_on:
+      - estuary-main
     build:
       context: ./estuary-shuttle
       dockerfile: Dockerfile
-    depends_on:
-      - estuary-main
     ports:
       - "3005:3005"
       - "3005:3005/udp"
     environment:
       - ESTUARY_HOSTNAME=estuary-main:3004
     volumes:
+      - estuary-bin:/usr/estuary-bin/
       - estuary:/usr/estuary/private
   
   estuary-www:
@@ -45,3 +47,4 @@ services:
     
 volumes:
   estuary: 
+  estuary-bin: 

--- a/estuary-main/Dockerfile
+++ b/estuary-main/Dockerfile
@@ -13,6 +13,7 @@ RUN git clone https://github.com/application-research/estuary . && \
     
 COPY start.sh /usr/src/estuary/start.sh
 RUN chmod +x /usr/src/estuary/start.sh
+RUN cp /usr/src/estuary/estuary-shuttle /usr/estuary-bin/ # for the shuttle shared volume
 
 #ENV ESTUARY_TOKEN=$(/usr/src/estuary/start.sh)
 #RUN echo Estuary Token is ${ESTUARY_TOKEN}

--- a/estuary-main/Dockerfile
+++ b/estuary-main/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.16.11-stretch
 RUN apt-get update && \
     apt-get install -y wget jq hwloc ocl-icd-opencl-dev git libhwloc-dev pkg-config make  && \
     apt-get install -y cargo
+WORKDIR /usr/estuary-bin
 WORKDIR /usr/src/estuary
 EXPOSE 3004
 

--- a/estuary-shuttle/Dockerfile
+++ b/estuary-shuttle/Dockerfile
@@ -6,8 +6,6 @@ WORKDIR /usr/src/estuary-shuttle
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cargo --help
-RUN git clone https://github.com/application-research/estuary . && \
-    RUSTFLAGS="-C target-cpu=native -g" FFI_BUILD_FROM_SOURCE=1 make all
 
 COPY start.sh /usr/src/estuary-shuttle/start.sh
 RUN chmod +x /usr/src/estuary-shuttle/start.sh

--- a/estuary-shuttle/Dockerfile
+++ b/estuary-shuttle/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.16.11-stretch
 RUN apt-get update && \
     apt-get install -y wget jq hwloc ocl-icd-opencl-dev git libhwloc-dev pkg-config make  && \
     apt-get install -y cargo
+WORKDIR /usr/estuary-bin
 WORKDIR /usr/src/estuary-shuttle
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/estuary-shuttle/start.sh
+++ b/estuary-shuttle/start.sh
@@ -1,13 +1,7 @@
 #/bin/bash
-ESTUARY_TOKEN=$(cat /usr/estuary/private/token)
-FILE=/usr/src/estuary/data/estuary-shuttle.db
-if test -f "$FILE"; then
-    echo "$FILE exists."
-else
-    echo "$FILE does not exist."
-fi
 
-sleep 10s
+sleep 20s
+ESTUARY_TOKEN=$(cat /usr/estuary/private/token)
 genKey=$(curl -H "Authorization: Bearer $ESTUARY_TOKEN" -X POST http://$ESTUARY_HOSTNAME/admin/shuttle/init)
 ESTUARY_SHUTTLE_HANDLE=$(echo $genKey | jq -r '.handle')
 ESTUARY_SHUTTLE_TOKEN=$(echo $genKey | jq -r '.token')

--- a/estuary-shuttle/start.sh
+++ b/estuary-shuttle/start.sh
@@ -17,5 +17,5 @@ echo "Shuttle Token: $ESTUARY_SHUTTLE_TOKEN"
 echo "Shuttle Handle: $ESTUARY_SHUTTLE_HANDLE"
 echo "Estuary Token: $ESTUARY_TOKEN"
 
-/usr/src/estuary-shuttle/estuary-shuttle --dev --estuary-api=$ESTUARY_HOSTNAME --auth-token=$ESTUARY_SHUTTLE_TOKEN --handle=$ESTUARY_SHUTTLE_HANDLE
+/usr/estuary-bin/estuary-shuttle --dev --estuary-api=$ESTUARY_HOSTNAME --auth-token=$ESTUARY_SHUTTLE_TOKEN --handle=$ESTUARY_SHUTTLE_HANDLE
 # tail -f /dev/null

--- a/estuary-shuttle/start.sh
+++ b/estuary-shuttle/start.sh
@@ -11,5 +11,6 @@ echo "Shuttle Token: $ESTUARY_SHUTTLE_TOKEN"
 echo "Shuttle Handle: $ESTUARY_SHUTTLE_HANDLE"
 echo "Estuary Token: $ESTUARY_TOKEN"
 
+export LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/
 /usr/estuary-bin/estuary-shuttle --dev --estuary-api=$ESTUARY_HOSTNAME --auth-token=$ESTUARY_SHUTTLE_TOKEN --handle=$ESTUARY_SHUTTLE_HANDLE
 # tail -f /dev/null


### PR DESCRIPTION
Make estuary-docker compile times 2x faster because estuary-main and estuary-shuttle were both compiling their own estuary binary. Now the shuttle binary is shared from estuary-main

still testing this on my side, i'll confirm in this PR when the test finishes compiling / succeeds 