### PR TITLE
estuary-main - Autocreate /usr/estuary/private

### DIFF
--- a/estuary-main/start.sh
+++ b/estuary-main/start.sh
@@ -18,6 +18,7 @@ if test -f "$FILE"; then
 else
     echo "$FILE does not exist."
     mkdir -p /usr/src/estuary/data
+    mkdir -p /usr/estuary/private/
     AUTH_KEY=$(/usr/src/estuary/estuary setup --username admin --password Password123 | grep Token | cut -d ' ' -f 3)
     echo $AUTH_KEY
     echo $AUTH_KEY > /usr/estuary/private/token


### PR DESCRIPTION
This change adds a `mkdir -p` to create /usr/estuary/private on initialisation. This prevents an issue where the token fails to save.

```
  | 
-- | --
Sat, Oct 8 2022 8:15:31 pm | FULLNODE_API_INFO is empty, use default value
Sat, Oct 8 2022 8:15:31 pm | HOSTNAME: estuary-main
Sat, Oct 8 2022 8:15:31 pm | FULLNODE_API_INFO: wss://api.chain.love
Sat, Oct 8 2022 8:15:31 pm | /usr/src/estuary/data/estuary.db does not exist.
Sat, Oct 8 2022 8:15:32 pm | /usr/src/estuary/start.sh: 23: cannot create /usr/estuary/private/token: Directory nonexistent
```